### PR TITLE
Implement Inclement Emerald weather behaviors

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -125,7 +125,7 @@
 
 // Ability settings
 #define B_EXPANDED_ABILITY_NAMES    TRUE       // If TRUE, ability names are increased from 12 characters to 16 characters.
-#define B_ABILITY_WEATHER           GEN_LATEST // In Gen6+, ability-induced weather lasts 5 turns. Before, it lasted until the battle ended or until it was changed by a move or a different weather-affecting ability.
+#define B_ABILITY_WEATHER           GEN_5 // In Gen6+, ability-induced weather lasts 5 turns. Before, it lasted until the battle ended or until it was changed by a move or a different weather-affecting ability.
 #define B_GALE_WINGS                GEN_6 // In Gen7+ requires full HP to trigger.
 #define B_STANCE_CHANGE_FAIL        GEN_LATEST // In Gen7+, Stance Change fails if the Pokémon is unable to use a move because of confusion, paralysis, etc. In Gen6, it doesn't.
 #define B_SHADOW_TAG_ESCAPE         GEN_LATEST // In Gen4+, if both sides have a Pokémon with Shadow Tag, all battlers can escape. Before, neither side could escape this situation.

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -9927,17 +9927,29 @@ static uq4_12_t GetWeatherDamageModifier(u32 battlerAtk, u32 move, u32 moveType,
     if (holdEffectDef == HOLD_EFFECT_UTILITY_UMBRELLA)
         return UQ_4_12(1.0);
 
-    if (weather & B_WEATHER_RAIN)
+    if (weather & B_WEATHER_RAIN_TEMPORARY)
     {
         if (moveType != TYPE_FIRE && moveType != TYPE_WATER)
             return UQ_4_12(1.0);
         return (moveType == TYPE_FIRE) ? UQ_4_12(0.5) : UQ_4_12(1.5);
     }
-    if (weather & B_WEATHER_SUN)
+    else if (weather & (B_WEATHER_RAIN_PERMANENT))
+    {
+        if (moveType != TYPE_FIRE && moveType != TYPE_WATER)
+            return UQ_4_12(1.0);
+        return (moveType == TYPE_FIRE) ? UQ_4_12(0.5) : UQ_4_12(1.2);
+    }
+    else if (weather & B_WEATHER_SUN_TEMPORARY)
     {
         if (moveType != TYPE_FIRE && moveType != TYPE_WATER)
             return UQ_4_12(1.0);
         return (moveType == TYPE_WATER) ? UQ_4_12(0.5) : UQ_4_12(1.5);
+    }
+    else if (weather & B_WEATHER_SUN_PERMANENT)
+    {
+        if (moveType != TYPE_FIRE && moveType != TYPE_WATER)
+            return UQ_4_12(1.0);
+        return (moveType == TYPE_WATER) ? UQ_4_12(0.5) : UQ_4_12(1.2);
     }
     return UQ_4_12(1.0);
 }

--- a/test/battle/ability/protosynthesis.c
+++ b/test/battle/ability/protosynthesis.c
@@ -77,10 +77,6 @@ SINGLE_BATTLE_TEST("Protosynthesis ability pop up activates only once during the
                 MESSAGE("Walking Wake's Sp. Atk was heightened!");
             }
         }
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUNNY_DAY, opponent);
-        ABILITY_POPUP(player, ABILITY_PROTOSYNTHESIS);
-        MESSAGE("The harsh sunlight activated Walking Wake's Protosynthesis!");
-        MESSAGE("Walking Wake's Sp. Atk was heightened!");
     }
 }
 

--- a/test/battle/hold_effect/booster_energy.c
+++ b/test/battle/hold_effect/booster_energy.c
@@ -39,24 +39,15 @@ SINGLE_BATTLE_TEST("Booster Energy will activate Protosynthesis after harsh sunl
 {
     GIVEN {
         PLAYER(SPECIES_RAGING_BOLT) { Attack(100); Defense(100); Speed(100); SpAttack(110); SpDefense(100); Ability(ABILITY_PROTOSYNTHESIS); Item(ITEM_BOOSTER_ENERGY); }
-        OPPONENT(SPECIES_TORKOAL) { Speed(100); Ability(ABILITY_DROUGHT); };
+        OPPONENT(SPECIES_TORKOAL) { Speed(100); Ability(ABILITY_DROUGHT); }
     } WHEN {
-        TURN {}
-        TURN {}
-        TURN {}
-        TURN {}
-        TURN {}
+        TURN {MOVE(player, MOVE_RAIN_DANCE);}
     } SCENE {
         ABILITY_POPUP(opponent, ABILITY_DROUGHT);
-        NONE_OF {
-            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            MESSAGE("Raging Bolt used its Booster Energy to activate Protosynthesis!");
-            MESSAGE("Raging Bolt's Sp. Atk was heightened!");
-        }
         ABILITY_POPUP(player, ABILITY_PROTOSYNTHESIS);
         MESSAGE("The harsh sunlight activated Raging Bolt's Protosynthesis!");
         MESSAGE("Raging Bolt's Sp. Atk was heightened!");
-        MESSAGE("The sunlight faded.");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_RAIN_DANCE, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
         ABILITY_POPUP(player, ABILITY_PROTOSYNTHESIS);
         MESSAGE("Raging Bolt used its Booster Energy to activate Protosynthesis!");


### PR DESCRIPTION
## Description
Inclement Emerald uses Gen V- standards for weather-causing abilities, and as such weather caused by Sandstorm(Ability), Drought, Drizzle, Snow Warning etc. are indefinite.

Inclement Emerald also changes typed damage boosts in different variants of weather - Fire moves do 1.2x damage in permanent (Drought) sun, but 1.5x damage in temporary (Sunny Day) sun.  Same with Water moves and Drizzle/Rain Dance.

## **Discord contact info**
@rwntr.
